### PR TITLE
add nvcc compiler from nvidia

### DIFF
--- a/docker/gcc-explorer/Dockerfile
+++ b/docker/gcc-explorer/Dockerfile
@@ -1,6 +1,12 @@
 FROM mattgodbolt/compiler-explorer:base
 MAINTAINER Matt Godbolt <matt@godbolt.org>
 
+# Add nvcc compiler from Nvidia
+RUN curl ${http_proxy:+--proxy $http_proxy} http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub | apt-key add - ; \
+    echo 'deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /' > /etc/apt/sources.list.d/cuda.list ; \
+    apt-get update && apt install -y cuda-minimal-build-8-0 ; \
+    rm -rf /var/lib/apt/lists/*
+
 COPY *.sh /
 
 USER gcc-user


### PR DESCRIPTION
nvcc was mentioned as desirable in mattgodbolt/compiler-explorer/issues/82

with attached patch:

<pre>
 docker run -ti  mattgodbolt/compiler-explorer:gcc  /usr/local/cuda-8.0/bin/nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2016 NVIDIA Corporation
Built on Tue_Jan_10_13:22:03_CST_2017
Cuda compilation tools, release 8.0, V8.0.61
</pre>