### PR TITLE
Add nvcc compiler from nvidia

### DIFF
--- a/update_compilers/install_compilers.sh
+++ b/update_compilers/install_compilers.sh
@@ -413,6 +413,15 @@ if [ ! -d "libs/boost_1_64_0" ]; then
     popd
     rm -rf /tmp/boost
 fi
+
+# nvcc
+curl ${http_proxy:+--proxy $http_proxy} http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub | apt-key add -
+echo 'deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /' > /etc/apt/sources.list.d/cuda.list
+apt-get update && apt install -y cuda-minimal-build-8-0
+rm -rf /var/lib/apt/lists/*
+mv /usr/local/cuda-8.0 ${OPT}/
+do_strip ${OPT}/cuda-8.0
+
 #########################
 
 


### PR DESCRIPTION
This add the nvcc compiler to the NFS dir and packs it. It uses a deb package as that's only how nvidia distribute it. It works ok in its moved location.

To invoke from compiler explorer the following invocation outputs a stdout ASM from a x.cu source file.
<code>
$OPT/cuda-8.0/bin/nvcc -ptx  --output-file - x.cu
</code>

I was having trouble following the compiler explorer javascript lib/base-compiler.js to work out how to best implement this. Is it ok to leave this with you?

A sample input I used was
<pre>
// http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compilation-with-nvcc

// Matrices are stored in row-major order:
// M(row, col) = *(M.elements + row * M.width + col)
typedef struct {
    int width;
    int height;
    float* elements;
} Matrix;

// Thread block size
#define BLOCK_SIZE 16

// Forward declaration of the matrix multiplication kernel
__global__ void MatMulKernel(const Matrix, const Matrix, Matrix);

// Matrix multiplication - Host code
// Matrix dimensions are assumed to be multiples of BLOCK_SIZE
void MatMul(const Matrix A, const Matrix B, Matrix C)
{
    // Load A and B to device memory
    Matrix d_A;
    d_A.width = A.width; d_A.height = A.height;
    size_t size = A.width * A.height * sizeof(float);
    cudaMalloc(&d_A.elements, size);
    cudaMemcpy(d_A.elements, A.elements, size,
               cudaMemcpyHostToDevice);
    Matrix d_B;
    d_B.width = B.width; d_B.height = B.height;
    size = B.width * B.height * sizeof(float);
    cudaMalloc(&d_B.elements, size);
    cudaMemcpy(d_B.elements, B.elements, size,
               cudaMemcpyHostToDevice);

    // Allocate C in device memory
    Matrix d_C;
    d_C.width = C.width; d_C.height = C.height;
    size = C.width * C.height * sizeof(float);
    cudaMalloc(&d_C.elements, size);

    // Invoke kernel
    dim3 dimBlock(BLOCK_SIZE, BLOCK_SIZE);
    dim3 dimGrid(B.width / dimBlock.x, A.height / dimBlock.y);
    MatMulKernel<<<dimGrid, dimBlock>>>(d_A, d_B, d_C);

    // Read C from device memory
    cudaMemcpy(C.elements, d_C.elements, size,
               cudaMemcpyDeviceToHost);

    // Free device memory
    cudaFree(d_A.elements);
    cudaFree(d_B.elements);
    cudaFree(d_C.elements);
}

// Matrix multiplication kernel called by MatMul()
__global__ void MatMulKernel(Matrix A, Matrix B, Matrix C)
{
    // Each thread computes one element of C
    // by accumulating results into Cvalue
    float Cvalue = 0;
    int row = blockIdx.y * blockDim.y + threadIdx.y;
    int col = blockIdx.x * blockDim.x + threadIdx.x;
    for (int e = 0; e < A.width; ++e)
        Cvalue += A.elements[row * A.width + e]
                * B.elements[e * B.width + col];
    C.elements[row * C.width + col] = Cvalue;
}
</pre>