### PR TITLE
Added cppcoro library

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -51,6 +51,7 @@ get_or_sync libs/xtensor https://github.com/QuantStack/xtensor.git
 get_or_sync libs/abseil https://github.com/abseil/abseil-cpp.git
 get_or_sync libs/cctz https://github.com/google/cctz.git
 get_or_sync libs/ctre https://github.com/hanickadot/compile-time-regular-expressions.git
+get_or_sync libs/cppcoro https://github.com/lewissbaker/cppcoro.git
 
 get_if_not_there() {
     local DIR=$1


### PR DESCRIPTION
Added cppcoro library.

This library does have a build step but looking at the existing libraries that also do (like Boost) it seems to be skipped. I'm guessing this means the dissassembly won't work for these code examples - but that's no big deal.