### PR TITLE
Fix stripping of Go compilers

### DIFF
--- a/update_compilers/install_compilers.sh
+++ b/update_compilers/install_compilers.sh
@@ -165,8 +165,8 @@ install_golang() {
     mkdir ${DIR}
     pushd ${DIR}
     fetch https://storage.googleapis.com/golang/go${VERSION}.linux-amd64.tar.gz | tar zxf -
-    do_strip ${DIR}
     popd
+    do_strip ${DIR}
 }
 
 install_golang 1.7.2


### PR DESCRIPTION
The current implementation always fails because the working directory is incorrect.