### PR TITLE
Build RISC-V support with clang trunk

### DIFF
--- a/clang/build/build.sh
+++ b/clang/build/build.sh
@@ -55,6 +55,7 @@ cmake -G "Unix Makefiles" ../llvm \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=/root/staging \
     -DLLVM_BINUTILS_INCDIR:PATH=/opt/compiler-explorer/gcc-7.2.0/lib/gcc/x86_64-linux-gnu/7.2.0/plugin/include/
+    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV"
 
 make -j$(nproc) install
 


### PR DESCRIPTION
This will allow adding riscv32 and riscv64 options to compiler explorer.