### PR TITLE
Add support for all Rust targets

### DIFF
--- a/update_compilers/common.inc
+++ b/update_compilers/common.inc
@@ -1,6 +1,7 @@
 OPT=/opt/compiler-explorer
 
 set -ex
+set -o pipefail
 mkdir -p ${OPT}
 cd ${OPT}
 

--- a/update_compilers/install_compilers.sh
+++ b/update_compilers/install_compilers.sh
@@ -40,10 +40,14 @@ fi
 do_rust_install() {
     local DIR=$1
     local INSTALL=$2
+    [[ ${DIR} = rust-std-* ]]
+    local IS_STD_LIB=$?
     pushd /tmp
-    fetch http://static.rust-lang.org/dist/${DIR}.tar.gz | tar zxvf -
+    fetch http://static.rust-lang.org/dist/${DIR}.tar.gz | tar zxvf - || return ${IS_STD_LIB}
     cd ${DIR}
-    rm -rf ${OPT}/${INSTALL}
+    if [[ ${IS_STD_LIB} -ne 0 ]]; then
+        rm -rf ${OPT}/${INSTALL}
+    fi
     ./install.sh --prefix=${OPT}/${INSTALL} --verbose --without=rust-docs
     rm -rf /tmp/${DIR}
     popd
@@ -74,7 +78,8 @@ install_rust() {
 
 install_new_rust() {
     local NAME=$1
-    local FORCE=$2
+    local -a TARGETS=("${!2}")
+    local FORCE=$3
     local DIR=rust-${NAME}
 
     if [[ -n "$FORCE" && -d ${DIR} ]]; then
@@ -96,6 +101,9 @@ install_new_rust() {
     echo Installing rust $NAME
 
     do_rust_install rust-${NAME}-x86_64-unknown-linux-gnu rust-${NAME}
+    for TARGET in "${TARGETS[@]}"; do
+        do_rust_install rust-std-${NAME}-${TARGET} rust-${NAME}
+    done
 
     # workaround for LD_LIBRARY_PATH
     ${PATCHELF} --set-rpath '$ORIGIN/../lib' ${OPT}/rust-${NAME}/bin/rustc
@@ -110,35 +118,124 @@ install_new_rust() {
     # Don't strip (llvm SOs don't seem to like it and segfault during startup)
 }
 
-
+RUST_TARGETS=(
+    aarch64-unknown-linux-gnu
+    arm-linux-androideabi
+    arm-unknown-linux-gnueabi
+    arm-unknown-linux-gnueabihf
+    i686-apple-darwin
+    i686-pc-windows-gnu
+    i686-pc-windows-msvc
+    i686-unknown-linux-gnu
+    mips-unknown-linux-gnu
+    mipsel-unknown-linux-gnu
+    x86_64-apple-darwin
+    x86_64-pc-windows-gnu
+    x86_64-pc-windows-msvc
+    x86_64-unknown-linux-gnu
+    x86_64-unknown-linux-musl
+)
+install_new_rust 1.5.0 RUST_TARGETS[@]
+install_new_rust 1.6.0 RUST_TARGETS[@]
+install_new_rust 1.7.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    aarch64-apple-ios
+    armv7-apple-ios
+    armv7-unknown-linux-gnueabihf
+    armv7s-apple-ios
+    i386-apple-ios
+    powerpc-unknown-linux-gnu
+    powerpc64-unknown-linux-gnu
+    powerpc64le-unknown-linux-gnu
+    x86_64-apple-ios
+    x86_64-rumprun-netbsd
+)
+install_new_rust 1.8.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    i586-pc-windows-msvc
+    i686-linux-android
+    i686-unknown-freebsd
+    mips-unknown-linux-musl
+    mipsel-unknown-linux-musl
+    x86_64-unknown-freebsd
+    x86_64-unknown-netbsd
+)
+install_new_rust 1.9.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    aarch64-linux-android
+    armv7-linux-androideabi
+    i586-unknown-linux-gnu
+    i686-unknown-linux-musl
+)
+install_new_rust 1.10.0 RUST_TARGETS[@]
+install_new_rust 1.11.0 RUST_TARGETS[@]
+install_new_rust 1.12.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    mips64-unknown-linux-gnuabi64
+    mips64el-unknown-linux-gnuabi64
+    s390x-unknown-linux-gnu
+)
+install_new_rust 1.13.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    arm-unknown-linux-musleabi
+    arm-unknown-linux-musleabihf
+    armv7-unknown-linux-musleabihf
+    asmjs-unknown-emscripten
+    wasm32-unknown-emscripten
+)
+install_new_rust 1.14.0 RUST_TARGETS[@]
+install_new_rust 1.15.1 RUST_TARGETS[@]
+install_new_rust 1.16.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    aarch64-unknown-fuchsia
+    sparc64-unknown-linux-gnu
+    x86_64-unknown-fuchsia
+)
+install_new_rust 1.17.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    x86_64-linux-android
+)
+install_new_rust 1.18.0 RUST_TARGETS[@]
+install_new_rust 1.19.0 RUST_TARGETS[@]
+install_new_rust 1.20.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    x86_64-unknown-redox
+)
+install_new_rust 1.21.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    aarch64-unknown-linux-musl
+    sparcv9-sun-solaris
+    x86_64-sun-solaris
+)
+install_new_rust 1.22.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    x86_64-unknown-linux-gnux32
+)
+install_new_rust 1.23.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    armv5te-unknown-linux-gnueabi
+    wasm32-unknown-unknown
+)
+install_new_rust 1.24.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    i586-unknown-linux-musl
+    x86_64-unknown-cloudabi
+)
+install_new_rust 1.25.0 RUST_TARGETS[@]
+install_new_rust 1.26.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    armv5te-unknown-linux-musleabi
+    thumbv6m-none-eabi
+    thumbv7em-none-eabi
+    thumbv7em-none-eabihf
+    thumbv7m-none-eabi
+)
+install_new_rust 1.27.0 RUST_TARGETS[@]
+install_new_rust 1.27.1 RUST_TARGETS[@]
 if install_nightly; then
-    install_new_rust nightly '1 day'
-    install_new_rust beta '1 week'
+    install_new_rust nightly RUST_TARGETS[@] '1 day'
+    install_new_rust beta RUST_TARGETS[@] '1 week'
 fi
-install_new_rust 1.5.0
-install_new_rust 1.6.0
-install_new_rust 1.7.0
-install_new_rust 1.8.0
-install_new_rust 1.9.0
-install_new_rust 1.10.0
-install_new_rust 1.11.0
-install_new_rust 1.12.0
-install_new_rust 1.13.0
-install_new_rust 1.14.0
-install_new_rust 1.15.1
-install_new_rust 1.16.0
-install_new_rust 1.17.0
-install_new_rust 1.18.0
-install_new_rust 1.19.0
-install_new_rust 1.20.0
-install_new_rust 1.21.0
-install_new_rust 1.22.0
-install_new_rust 1.23.0
-install_new_rust 1.24.0
-install_new_rust 1.25.0
-install_new_rust 1.26.0
-install_new_rust 1.27.0
-install_new_rust 1.27.1
 
 install_rust 1.0.0
 install_rust 1.1.0


### PR DESCRIPTION
Hopefully this fixes:
- mattgodbolt/compiler-explorer#496
- mattgodbolt/compiler-explorer#786
- mattgodbolt/compiler-explorer#898

I've tested this locally (but on macOS). My testing was limited to making sure the downloads worked and I could specify `--target <triple>` to `rustc` and get the desired output.

It's a little messy. I'm happy to take comments on better ways to structure this. I thought about pulling out the Rust updating code into its own shell script. I was too lazy to do that, but I could be persuaded to not be lazy :)

It's worth pointing out that this doesn't consider failed std-lib installs to be an error. For example, Rust 1.21.0 doesn't contain Fuschia std-lib builds like it should, and this script just ignores that failure and proceeds as normal.