### PR TITLE
Turn -fpermissive errors into warnings while building clang

### DIFF
--- a/clang/build/build.sh
+++ b/clang/build/build.sh
@@ -55,7 +55,8 @@ cmake -G "Unix Makefiles" ../llvm \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=/root/staging \
     -DLLVM_BINUTILS_INCDIR:PATH=/opt/compiler-explorer/gcc-7.2.0/lib/gcc/x86_64-linux-gnu/7.2.0/plugin/include/ \
-    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV;WebAssembly"
+    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV;WebAssembly" \
+    -DCMAKE_CXX_FLAGS=-fpermissive
 
 make -j$(nproc) install
 


### PR DESCRIPTION
I've filled an LLVM build system bug: https://bugs.llvm.org/show_bug.cgi?id=38512