### PR TITLE
Install Agner Fogs vector class library

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -290,5 +290,3 @@ get_or_sync_git_tags() {
 }
 
 get_or_sync_git_tags libs/ctre https://github.com/hanickadot/compile-time-regular-expressions.git master v2
-
-get_github_versions libs/vcl darealshinji/vectorclass v1.30

--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -288,3 +288,5 @@ get_or_sync_git_tags() {
 }
 
 get_or_sync_git_tags libs/ctre https://github.com/hanickadot/compile-time-regular-expressions.git master v2
+
+get_github_versions libs/vcl darealshinji/vectorclass v1.30

--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -176,6 +176,8 @@ get_github_versioned_and_trunk libs/doctest onqtam/doctest 1.2.9
 
 get_github_versions libs/GSL Microsoft/GSL v1.0.0
 
+get_github_versions libs/vcl darealshinji/vectorclass v1.30
+
 install_blaze() {
     for VERSION in "$@"; do
         local DEST=${OPT}/libs/blaze/v${VERSION}/


### PR DESCRIPTION
The library is distributed through zip archives from the original author,
but there is a well-maintained github fork from darealshinji, which makes
the installation process easier and implementable with existing tools.