### PR TITLE
Add Advance Toolchain (IBM Power cross compiler) - gcc based

### DIFF
--- a/update_compilers/install_compilers.sh
+++ b/update_compilers/install_compilers.sh
@@ -570,6 +570,16 @@ if install_nightly; then
     do_nightly_install gcc-trunk gcc-snapshot
 fi
 
+# Advance Toolchain (By IBM for POWER)
+
+git clone --single-branch  --branch master https://github.com/advancetoolchain/advance-toolchain.git
+for version in 12.0 \
+; do
+    make -C advance-toolchain -j $(nproc) AT_MAKE_CHECK=silent_fail AT_CONFIGSET=${version} DESTDIR=${OPT} toolchain
+    do_strip ${OPT}/at${version}
+done
+
+
 # Custom-built clangs also stripped and UPX'd
 for version in \
     3.9.1 \


### PR DESCRIPTION
Let me know if this is too big and I'll see what I can cut down.

Seems to need the following build dependencies (16.04) but assuming 18.04 is the same:
<pre>
apt-get install -y lsb-release  autoconf  automake libtool m4  bison sed flex perl \
        cvs debhelper dpkg-sig gawk libncurses5-dev libxml2-utils ncurses-term subversion texinfo xutils-dev zlib1g-dev \
        autoconf-archive dh-systemd docbook2x pkg-config \
        wget git
</pre>

closes #20 
closes #mattgodbolt/compiler-explorer/issues/205 