### PR TITLE
Add -Wlifetime clang

### DIFF
--- a/admin-daily-builds.sh
+++ b/admin-daily-builds.sh
@@ -44,5 +44,6 @@ build_latest clang clang_concepts build-concepts.sh
 build_latest clang clang_cppx build-cppx.sh
 build_latest clang clang_relocatable build-relocatable.sh
 build_latest clang clang_autonsdmi build-autonsdmi.sh
+build_latest clang clang_lifetime build-lifetime.sh
 
 exit ${BUILD_FAILED}

--- a/clang/build/build-lifetime.sh
+++ b/clang/build/build-lifetime.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+# Grab CE's GCC 7.3.0 for its binutils (which is what the site uses to link currently)
+mkdir -p /opt/compiler-explorer
+pushd /opt/compiler-explorer
+curl -sL https://s3.amazonaws.com/compiler-explorer/opt/gcc-7.3.0.tar.xz | tar Jxf -
+popd
+
+ROOT=$(pwd)
+TAG=trunk
+VERSION=lifetime-trunk-$(date +%Y%m%d)
+
+OUTPUT=/root/clang-${VERSION}.tar.xz
+S3OUTPUT=""
+if echo $2 | grep s3://; then
+    S3OUTPUT=$2
+else
+    OUTPUT=${2-/root/clang-${VERSION}.tar.xz}
+fi
+
+STAGING_DIR=$(pwd)/staging
+rm -rf ${STAGING_DIR}
+mkdir -p ${STAGING_DIR}
+
+git clone https://github.com/llvm-mirror/llvm
+pushd llvm/tools
+git clone --depth 1 --single-branch -b lifetime https://github.com/mgehre/clang
+source ./clang/compiler-explorer-llvm-commit.sh
+popd
+
+mkdir build
+cd build
+cmake -G "Unix Makefiles" ../llvm \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DCMAKE_INSTALL_PREFIX:PATH=/root/staging \
+    -DLLVM_BINUTILS_INCDIR:PATH=/opt/compiler-explorer/gcc-7.3.0/lib/gcc/x86_64-linux-gnu/7.3.0/plugin/include/
+
+make -j$(nproc) install
+
+export XZ_DEFAULTS="-T 0"
+tar Jcf ${OUTPUT} --transform "s,^./,./clang-${VERSION}/," -C ${STAGING_DIR} .
+
+if [[ ! -z "${S3OUTPUT}" ]]; then
+    s3cmd put --rr ${OUTPUT} ${S3OUTPUT}
+fi

--- a/remove_old_compilers.sh
+++ b/remove_old_compilers.sh
@@ -16,4 +16,5 @@ remove_older clang-cppx-trunk
 remove_older clang-concepts-trunk
 remove_older clang-relocatable-trunk
 remove_older clang-autonsdmi-trunk
+remove_older clang-lifetime-trunk
 remove_older gcc

--- a/update_compilers/install_cpp_compilers.sh
+++ b/update_compilers/install_cpp_compilers.sh
@@ -207,6 +207,7 @@ if install_nightly; then
     do_nightly_install clang-concepts-trunk clang-concepts-trunk
     do_nightly_install clang-relocatable-trunk clang-relocatable-trunk
     do_nightly_install clang-autonsdmi-trunk clang-autonsdmi-trunk
+    do_nightly_install clang-lifetime-trunk clang-lifetime-trunk
 fi
 
 # Oracle dev studio is stored on s3 only as it's behind a login screen on the


### PR DESCRIPTION
We already have -Wlifetime in cppx, but that is a manual backport of our branch to LLVM 5. This PR builds the latest and greatest -Wlifetime which is currently on LLVM 6 and will soon track trunk very closely to enable upstreaming.