### PR TITLE
Compiler Argument Statistics loader/saver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.json
 .idea
 /.deploy
 .nfs*
+node_modules

--- a/analytics/.eslintignore
+++ b/analytics/.eslintignore
@@ -1,0 +1,3 @@
+package.json
+yarn.lock
+yarn-error.log

--- a/analytics/.eslintrc
+++ b/analytics/.eslintrc
@@ -1,0 +1,27 @@
+{
+  "root": true,
+  "extends": "eslint:recommended",
+  "env": {
+    "mocha": true,
+    "node": true,
+    "es6": true
+  },
+  "rules": {
+    "eqeqeq": ["error", "smart"],
+    "max-statements": ["error", 50],
+    "max-len": ["error", 120, { "ignoreRegExpLiterals": true }],
+    "eol-last": ["error", "always"],
+    "semi": ["error", "always"],
+    "indent": ["error", 4, { "SwitchCase": 1 }],
+    "no-control-regex": 0,
+    "space-before-function-paren": ["error", {
+      "anonymous": "always",
+      "named": "never",
+      "asyncArrow": "always"
+    }],
+    "quote-props": ["error", "as-needed"]
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+}

--- a/analytics/compilestats.js
+++ b/analytics/compilestats.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const
+    nopt = require('nopt'),
+    logger = require('./lib/logger').logger,
+    CompilerArgumentsWriter = require('./lib/compiler-arguments-writer');
+
+const opts = nopt({
+    region: [String],
+    bucket: [String],
+    accesstoken: [String]
+});
+
+function explainRequirementsAndExit() {
+    logger.error("usage: yarn start --region us-east-1 --bucket storage.godbolt.org --accesstoken googleapi1234");
+    process.exit(1);
+}
+
+function checkCommandLineParams() {
+    if (!opts) explainRequirementsAndExit();
+    if (!opts.region) explainRequirementsAndExit();
+    if (!opts.bucket) explainRequirementsAndExit();
+    if (!opts.accesstoken) explainRequirementsAndExit();
+}
+
+checkCommandLineParams();
+
+const baseUrl =
+    "https://www.googleapis.com/analytics/v3/data/ga" +
+    "?ids=ga:60096530" +
+    "&dimensions=ga:eventAction,ga:eventLabel" +
+    "&metrics=ga:totalEvents" +
+    "&sort=-ga:totalEvents" +
+    "&filters=ga:eventCategory%3D%3DCompile;ga:eventLabel!%3D(not+set)" +
+    "&start-date=30daysAgo" +
+    "&end-date=yesterday";
+
+const writer = new CompilerArgumentsWriter();
+writer.loadStatisticsFromGoogleStatsURL(baseUrl, opts.accesstoken).then(() => {
+    writer.save(opts.region, opts.bucket).then(() => {
+        logger.info("Done");
+    });
+});

--- a/analytics/install.sh
+++ b/analytics/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+PATH=$PATH:/opt/compiler-explorer/node/bin
+npm install

--- a/analytics/lib/compiler-arguments-writer.js
+++ b/analytics/lib/compiler-arguments-writer.js
@@ -63,7 +63,7 @@ class CompilerArgumentsWriter {
     }
 
     saveToStorage(s3, compilerId, stats) {
-        return s3.put(compilerId + ".json", stats, this.prefix);
+        return s3.put(compilerId + ".json", stats, this.prefix, {});
     }
 
     save(region, bucket) {

--- a/analytics/lib/compiler-arguments-writer.js
+++ b/analytics/lib/compiler-arguments-writer.js
@@ -1,0 +1,141 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+const
+    _ = require('underscore'),
+    quote = require('shell-quote'),
+    logger = require('./logger').logger,
+    https = require('https'),
+    AWS = require('aws-sdk'),
+    S3Bucket = require('./s3-handler');
+
+class CompilerArgumentsWriter {
+    constructor() {
+        this.arguments = {};
+        this.prefix = "compargs";
+
+        this.promiseList = [];
+    }
+
+    addOptionsToStatistics(compilerId, args, times) {
+        try {
+            times = Number.parseInt(times, 10);
+            if (times === NaN) times = Number.MAX_SAFE_INTEGER;
+        } catch(e) {
+            times = Number.MAX_SAFE_INTEGER;
+        }
+
+        _.each(args, (arg) => {
+            if (arg === "-") return;
+
+            if (!this.arguments[compilerId]) {
+                this.arguments[compilerId] = {};
+            }
+
+            if (!this.arguments[compilerId][arg]) {
+                this.arguments[compilerId][arg] = times
+            } else {
+                this.arguments[compilerId][arg] += times;
+            }
+        });
+    }
+
+    saveToStorage(s3, compilerId, stats) {
+        return s3.put(compilerId + ".json", stats, this.prefix);
+    }
+
+    save(region, bucket) {
+        AWS.config.update({ region: region });
+        const s3 = new S3Bucket(bucket, region);
+
+        return new Promise((resolve) => {
+            const list = _.keys(this.arguments).map((compilerId) => {
+                this.saveToStorage(s3, compilerId, this.arguments[compilerId]);
+            });
+
+            resolve(Promise.all(list));
+        }, this);
+    }
+
+    loadStatisticsFromGoogleStatsURL(url, accesstoken) {
+        return new Promise((resolve, reject) => {
+            https.get(url + "&access_token=" + accesstoken, (res) => {
+                const { statusCode } = res;
+
+                let error;
+                if (statusCode !== 200) {
+                    error = new Error(
+                        `Request Failed (GET ${url}).\n` +
+                        `Status Code: ${statusCode}`);
+                }
+
+                if (error) {
+                    logger.error(error.message);
+                    res.resume();
+                    reject(error.message);
+                    return;
+                }
+
+                let rawdata = "";
+
+                res.on('data', (chunk) => rawdata += chunk);
+                res.on('end', () => {
+                    const data = JSON.parse(rawdata);
+
+                    data.rows.forEach(row => {
+                        try {
+                            const args = _.chain(quote.parse(row[1] || '')
+                                .map(x => typeof (x) === "string" ? x : x.pattern))
+                                .compact()
+                                .value();
+                            this.addOptionsToStatistics(row[0], args, row[2]);
+                        } catch(e) {
+                            // ignore
+                        }
+                    }, this);
+
+                    if (data.nextLink) {
+                        logger.info("Found more data...");
+                        resolve(data.nextLink);
+                    } else {
+                        logger.info("That was all she wrote");
+                        resolve(false);
+                    }
+                }, this);
+            }, this).on('error', (e) => {
+                logger.error(e);
+                reject(e);
+            });
+        }).then((nextLink) => {
+            if (nextLink) {
+                return this.loadStatisticsFromGoogleStatsURL(nextLink, accesstoken);
+            } else {
+                return false;
+            }
+        }, this);
+    }
+}
+
+module.exports = CompilerArgumentsWriter;

--- a/analytics/lib/logger.js
+++ b/analytics/lib/logger.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, Matt Godbolt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const winston = require('winston');
+
+const logger = new (winston.Logger)({
+    transports: [
+        new (winston.transports.Console)({colorize: true})
+    ]
+});
+
+logger.stream = {
+    write: message => {
+        logger.info(message.trim());
+    }
+};
+
+logger.warnStream = {
+    write: message => {
+        logger.warn(message.trim());
+    }
+};
+
+logger.errStream = {
+    write: message => {
+        logger.error(message.trim());
+    }
+};
+
+exports.logger = logger;

--- a/analytics/lib/s3-handler.js
+++ b/analytics/lib/s3-handler.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2018, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+const AWS = require('aws-sdk');
+
+class S3Bucket {
+    constructor(bucket, region) {
+        this.instance = new AWS.S3({region});
+        this.bucket = bucket;
+        this.region = region;
+    }
+
+    get(key, path) {
+        return this.instance.getObject({Bucket: this.bucket, Key: `${path}/${key}`})
+            .promise()
+            .then(result => {
+                return {hit: true, data: result.Body};
+            })
+            .catch(x => {
+                if (x.code === 'NoSuchKey') return {hit: false};
+                throw x;
+            });
+    }
+
+    put(key, value, path, options) {
+        const metadata = options.metadata || {};
+        const redundancy = options.redundancy || "STANDARD";
+        return this.instance.putObject({
+            Bucket: this.bucket, Key: `${path}/${key}`, Body: value,
+            StorageClass: redundancy,
+            Metadata: metadata
+        }).promise();
+    }
+}
+
+module.exports = S3Bucket;

--- a/analytics/package.json
+++ b/analytics/package.json
@@ -8,7 +8,7 @@
         "type": "git",
         "url": "mattgodbolt/compiler-explorer-image/analytics"
     },
-    "version": "0.1",
+    "version": "0.1.0",
     "engines": {
         "node": ">=8"
     },

--- a/analytics/package.json
+++ b/analytics/package.json
@@ -1,0 +1,52 @@
+{
+    "name": "compiler-explorer",
+    "description": "Retreive Google analytics for use in Compiler Explorer",
+    "author": {
+        "name": "Compiler Explorer Team"
+    },
+    "repository": {
+        "type": "git",
+        "url": "mattgodbolt/compiler-explorer-image/analytics"
+    },
+    "version": "0.1",
+    "engines": {
+        "node": ">=8"
+    },
+    "main": "./compilestats.js",
+    "dependencies": {
+        "aws-sdk": "^2.177.0",
+        "cross-env": "^5.1.3",
+        "denodeify": "^1.2.1",
+        "fs-extra": "^7.0.0",
+        "nopt": "3.0.x",
+        "shell-quote": "1.6.x",
+        "underscore": "1.9.1",
+        "winston": "^2.4.0",
+        "yarn": "^1.7.0"
+    },
+    "devDependencies": {
+        "aws-sdk-mock": "^1.7.0",
+        "chai": "3.5.x",
+        "chai-as-promised": "^7.1.1",
+        "chai-http": "^3.0.0",
+        "codecov": "^3.0.0",
+        "eslint": "^4.17.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.3.0",
+        "nock": "^9.1.4",
+        "requirejs": "*",
+        "style-loader": "^0.19.0",
+        "supervisor": "*",
+        "uglify-js": "*"
+    },
+    "scripts": {
+        "lint": "eslint --config .eslintrc --ignore-path .eslintignore --fix ./*",
+        "test": "mocha --recursive",
+        "check": "yarn run lint && yarn run test",
+        "start": "node compilestats.js",
+        "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
+        "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
+        "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"
+    },
+    "license": "BSD-2-Clause"
+}


### PR DESCRIPTION
Loads Google analytics data in for compiler arguments and save them in an S3 bucket,
needs to be manually started with a Google API accesstoken

It works, but before merge:
- [ ] Add documentation
- [ ] Make startup a bit more user-friendly
- [ ] Have a minimum times-used treshhold on when to save a param
