### PR TITLE
Support for GNAT

### DIFF
--- a/gcc/Dockerfile
+++ b/gcc/Dockerfile
@@ -11,6 +11,7 @@ RUN apt update -y -q && apt upgrade -y -q && apt upgrade -y -q&& apt install -y 
     gawk \
     g++ \
     gcc \
+    gnat \
     libc6-dev-i386 \
     libelf-dev \
     linux-libc-dev \

--- a/gcc/build/build.sh
+++ b/gcc/build/build.sh
@@ -96,7 +96,7 @@ CONFIG+=" --with-abi=m64"
 CONFIG+=" --with-multilib-list=m32,m64,mx32"
 CONFIG+=" --enable-multilib"
 CONFIG+=" --enable-clocale=gnu"
-CONFIG+=" --enable-languages=c,c++,fortran" # used to have go, but is incompatible with m32/mx32
+CONFIG+=" --enable-languages=c,c++,fortran,ada" # used to have go, but is incompatible with m32/mx32
 CONFIG+=" --enable-ld=yes"
 CONFIG+=" --enable-gold=yes"
 CONFIG+=" --enable-libstdcxx-debug"


### PR DESCRIPTION
Hi,

I have added the necessary changes that should enable GNAT to be built within GCC. The change to the Dockerfile includes GNAT as a prerequisite for actually compiling [GNAT itself](https://gcc.gnu.org/install/prerequisites.html) as the front-end of GNAT is written in Ada. I haven't tested the Dockerfile itself, however I have been able to successfully build and install GCC 8.2 from source using the configuration outlined in build.sh on an Ubuntu 18.04 VM and successfully get everything (including GNAT) to build and work. 

Compilation of GNAT requires that the version of GNAT being used is [GCC 4.0](https://gcc.gnu.org/install/build.html) or later and from my VM the default version of GNAT retrieved from `apt-get` is 7.3.0 which is more than sufficient.

These changes relate to [CE Issue #1190 (Ada language support)](https://github.com/mattgodbolt/compiler-explorer/pull/1190)

If there is something I may have overlooked please let me know.