### PR TITLE
Updated doctest library to 2.2.2

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -177,7 +177,7 @@ get_github_versioned_and_trunk libs/catch2 catchorg/Catch2 v2.2.2 v2.2.3
 get_github_versions libs/expected-lite martinmoene/expected-dark v0.0.1
 get_github_versioned_and_trunk libs/expected-lite martinmoene/expected-lite v0.1.0
 get_github_versioned_and_trunk libs/nlohmann_json nlohmann/json v3.1.2 v2.1.1
-get_github_versioned_and_trunk libs/doctest onqtam/doctest 1.2.9 2.0.0 2.0.1 2.1.0 2.2.0 2.2.1
+get_github_versioned_and_trunk libs/doctest onqtam/doctest 1.2.9 2.0.0 2.0.1 2.1.0 2.2.0 2.2.1 2.2.2
 get_github_versioned_and_trunk libs/eastl electronicarts/EASTL 3.12.01
 
 get_github_versions libs/GSL Microsoft/GSL v1.0.0


### PR DESCRIPTION
New version [released](https://github.com/onqtam/doctest/blob/master/CHANGELOG.md#222-2019-01-25)