### PR TITLE
add new available rust targets

### DIFF
--- a/update_compilers/install_rust_compilers.sh
+++ b/update_compilers/install_rust_compilers.sh
@@ -209,6 +209,8 @@ install_new_rust 1.33.0 RUST_TARGETS[@]
 if install_nightly; then
     RUST_TARGETS+=(
         riscv32imac-unknown-none-elf
+        riscv64imac-unknown-none-elf
+        riscv64gc-unknown-none-elf
     )
     install_new_rust nightly RUST_TARGETS[@] '1 day'
     install_new_rust beta RUST_TARGETS[@] '1 week'


### PR DESCRIPTION
In rust nightly and beta, targets `riscv64gc-unknown-none-elf` and `riscv64imac-unknown-none-elf` are available now, just add them.
In addition, `riscv32imac-unknown-none-elf` and `riscv32imc-unknown-none-elf` are available on Rust 1.33.0 at least, we can move `riscv32imac-unknown-none-elf` out of nightly and add them for next stable Rust .