### PR TITLE
Change the target branch for cppx to "compiler-explorer"

### DIFF
--- a/clang/build/build-cppx.sh
+++ b/clang/build/build-cppx.sh
@@ -29,7 +29,7 @@ git clone --single-branch https://github.com/llvm-mirror/llvm.git
 
 # Checkout & configure clang
 pushd llvm/tools
-git clone --depth 1 --single-branch -b feature/metaprogramming https://gitlab.com/lock3/clang.git
+git clone --depth 1 --single-branch -b compiler-explorer https://gitlab.com/lock3/clang.git
 
 # Load llvm revisions for this compiler build
 pushd clang


### PR DESCRIPTION
Hi Matt,

We're intending to bring the lifetime work back into cppx. I've made a more generic "compiler-explorer" branch now, so if we decide to make further changes on our side (and/or change our minds) we won't have to take more of your time.

Thanks,

Wyatt