### PR TITLE
Revert "Install binutils-multiarch so that clang cross-compilation works"

### DIFF
--- a/gcc-cross/Dockerfile
+++ b/gcc-cross/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get install -y -q \
     gawk \
     gcc \
     g++ \
-    binutils-multiarch \
     gperf \
     help2man \
     libc6-dev-i386 \


### PR DESCRIPTION
Reverts mattgodbolt/compiler-explorer-image#192