### PR TITLE
Add Raspbian Stretch toolchain to image

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -91,6 +91,17 @@ compilers:
                 - year: 2019
                   build: 3
                   name: 6.3.0
+          - type: tarballs
+            raspbian:
+              check_exe: bin/arm-raspbian{dist}-linux-gnueabihf-g++ --version
+              compression: gz
+              dir: arm/raspbian{dist}-{name}
+              untar_dir: raspbian{dist}
+              url: https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v{build}/Raspbian{dist}-Linux-Toolchain-{name}.tar.gz
+              targets:
+                - dist: 9
+                  build: 1.3.0
+                  name: 6.3.0
         avr:
           arch_prefix: avr
           subdir: avr

--- a/update_compilers/install_cpp_compilers.sh
+++ b/update_compilers/install_cpp_compilers.sh
@@ -242,6 +242,11 @@ if [[ ! -d arm/frc2019-6.3.0 ]]; then
     mv frc2019 arm/frc2019-6.3.0
 fi
 
+# Raspbian Specific toolchain
+if [[ ! -d gcc-raspbian-stretch ]]; then
+        fetch https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v1.3.0/Raspbian9-Linux-Toolchain-6.3.0.tar.gz | tar xzf -
+fi
+
 # intel ispc
 get_ispc() {
     local VER=$1

--- a/update_compilers/install_cpp_compilers.sh
+++ b/update_compilers/install_cpp_compilers.sh
@@ -243,8 +243,9 @@ if [[ ! -d arm/frc2019-6.3.0 ]]; then
 fi
 
 # Raspbian Specific toolchain
-if [[ ! -d raspbian9 ]]; then
+if [[ ! -d arm/raspbian9-6.3.0 ]]; then
     fetch https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v1.3.0/Raspbian9-Linux-Toolchain-6.3.0.tar.gz | tar xzf -
+    mv raspbian9 arm/raspbian9-6.3.0
 fi
 
 # intel ispc

--- a/update_compilers/install_cpp_compilers.sh
+++ b/update_compilers/install_cpp_compilers.sh
@@ -243,8 +243,8 @@ if [[ ! -d arm/frc2019-6.3.0 ]]; then
 fi
 
 # Raspbian Specific toolchain
-if [[ ! -d gcc-raspbian-stretch ]]; then
-        fetch https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v1.3.0/Raspbian9-Linux-Toolchain-6.3.0.tar.gz | tar xzf -
+if [[ ! -d raspbian9 ]]; then
+    fetch https://github.com/wpilibsuite/raspbian-toolchain/releases/download/v1.3.0/Raspbian9-Linux-Toolchain-6.3.0.tar.gz | tar xzf -
 fi
 
 # intel ispc


### PR DESCRIPTION
Our organization builds prebuilt cross compilers for common platforms, with one of these platforms being the Raspberry Pi. Looking through the existing compilers, I noticed that there was no Arm compiler that has the Hard Float ABI available. As the Raspberry Pi is an extremely common platform, I think having a specific compiler for it would be a great idea. A generic one could be added, however at that point users would have to manually put in arguments to actually match what is compiled to on the Raspberry Pi itself. By using a compiler specifically for it, that will no longer be required.

I tested this locally, and will be happy to add this selection to the main compiler-explorer repo once this is in.

We also build a compiler specifically for National Instruments Linux Real-Time (ArmV7 SoftFP) platforms, which I tested as well, but I suspect thats less useful and would likely not be accepted, but if it would be I would happily add that as well. We would use it as a teaching tool, as that is our main supported platform, but it would be a very specific use case.

If curious about how we build this, we build it via the following repo. 
https://github.com/wpilibsuite/raspbian-toolchain