### PR TITLE
Add FRC/NI Real-Time compiler

### DIFF
--- a/update_compilers/install_cpp_compilers.sh
+++ b/update_compilers/install_cpp_compilers.sh
@@ -236,6 +236,11 @@ if [[ ! -d gcc-arm-none-eabi-5_4-2016q3 ]]; then
     do_strip gcc-arm-none-eabi-5_4-2016q3
 fi
 
+# FIRST Robotics/ NI Real-Time Specific toolchain
+if [[ ! -d gcc-ni-realtime-18 ]]; then
+        fetch https://github.com/wpilibsuite/toolchain-builder/releases/download/v2019-3/FRC-2019-Linux-Toolchain-6.3.0.tar.gz | tar xzf -
+fi
+
 # intel ispc
 get_ispc() {
     local VER=$1


### PR DESCRIPTION
As I mentioned in #213, our organization also provides a pre-built compiler for the FIRST Robotics Competition, which runs on the National Instruments Linux Real-Time platform, which is a Cortex A9 with VFP and softfp. The platform can kind of be configured with one of the existing arm compilers, however I've noticed they're not exact, as there is some differences in the libc and kernel to support Real-Time as well. I think it would be a cool addition, and it would be awesome to be able to use as a teaching tool for the students how assembly works, with the exact assembly that comes from their primary compiler. 

I would completely understand if this is a bit to specialized and closed, but I figured I would create the PR to at least try. We update this compiler every year for the new image, and I would be happy to keep maintaining this in the future as well.