### PR TITLE
Add support for thumbv7neon Linux and Android Rust targets

### DIFF
--- a/update_compilers/install_rust_compilers.sh
+++ b/update_compilers/install_rust_compilers.sh
@@ -205,6 +205,10 @@ install_new_rust 1.29.0 RUST_TARGETS[@]
 install_new_rust 1.30.0 RUST_TARGETS[@]
 install_new_rust 1.31.0 RUST_TARGETS[@]
 install_new_rust 1.32.0 RUST_TARGETS[@]
+RUST_TARGETS+=(
+    thumbv7neon-unknown-linux-gnueabihf
+    thumbv7neon-linux-androideabi
+)
 install_new_rust 1.33.0 RUST_TARGETS[@]
 RUST_TARGETS+=(
     riscv32imac-unknown-none-elf


### PR DESCRIPTION
Closes https://github.com/mattgodbolt/compiler-explorer/issues/1271.

Note: Contrary to the contributing guidelines, I haven't run a local test, because unlike the README says, the script (even before my changes) appeared to want to have AWS credentials.