### PR TITLE
Enable elb access log stored to s3

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -16,6 +16,12 @@ resource "aws_alb" "GccExplorerApp" {
 
   enable_deletion_protection = false
 
+  access_logs {
+    bucket  = "${aws_s3_bucket.compiler-explorer-logs.bucket}"
+    prefix  = "elb"
+    enabled = true
+  }
+
   tags = {
     Site = "CompilerExplorer"
   }


### PR DESCRIPTION
logs flow into a new bucket named `compiler-explorer-logs`.
These changes have been applied to AWS already through terraform.