### PR TITLE
Install vector class library v2.0 into the image

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -209,6 +209,7 @@ get_github_versioned_and_trunk libs/PEGTL taocpp/PEGTL 2.8.0
 get_github_versions libs/GSL Microsoft/GSL v1.0.0 v2.0.0
 
 get_github_versions libs/vcl darealshinji/vectorclass v1.30
+get_github_versions libs/vcl vectorclass/version2 v2.00.01
 
 install_blaze() {
     for VERSION in "$@"; do


### PR DESCRIPTION
The library has migrated to a new GitHub repo starting with version 2.

I will open an accompanying PR on the CE in a minute.