### PR TITLE
Add new releases of Eigen3

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -194,7 +194,7 @@ get_github_versioned_and_trunk libs/libguarded copperspice/libguarded libguarded
 get_github_versioned_and_trunk libs/brigand edouarda/brigand 1.3.0
 get_github_versioned_and_trunk libs/fmt fmtlib/fmt 6.0.0 5.3.0 5.2.0 5.1.0 5.0.0 4.1.0 4.0.0
 get_github_versioned_and_trunk libs/hfsm andrew-gresyk/HFSM 0.8 0.10
-get_github_versioned_and_trunk_with_quirk libs/eigen eigenteam/eigen-git-mirror v 3.3.4
+get_github_versioned_and_trunk_with_quirk libs/eigen eigenteam/eigen-git-mirror v 3.3.4 3.3.5 3.3.7
 get_github_versioned_and_trunk libs/glm g-truc/glm 0.9.8.5 0.9.9.0 0.9.9.1 0.9.9.2 0.9.9.3 0.9.9.4 0.9.9.5 0.9.9.6
 get_github_versioned_and_trunk libs/catch2 catchorg/Catch2 v2.2.2 v2.2.3 v2.3.0 v2.4.0 v2.4.1 v2.4.2 v2.5.0 v2.6.0 v2.6.1 v2.7.0 v2.7.1 v2.7.2 v2.8.0 v2.9.0 v2.9.1 v2.9.2
 get_github_versions libs/expected-lite martinmoene/expected-dark v0.0.1


### PR DESCRIPTION
If possible, I'd like to see newer/current versions of Eigen3. I've added all released versions after 3.3.4 (the one that initially had been added). This adds the following versions:
- 3.3.5
- 3.3.6(*)
- 3.3.7

(*) I've added all newer releases so far, but 3.3.7 fixes a compilation issue with some versions of GCC. 
From the official [release notes](http://eigen.tuxfamily.org/index.php?title=News:Eigen_3.3.7_released!):
> This is a maintenance release fixing a compilation issue introduced in the previous 3.3.6 release. The compilation issue only occurred for some versions of GCC with compiler optimization turned off. 

So I've included version 3.3.6 for completeness, but one could also leave that version out, as it should be basically equivalent to 3.3.7.