### PR TITLE
install iwyu

### DIFF
--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -90,3 +90,22 @@ if [[ ! -d ${OPT}/x86-to-6502/lefticus ]]; then
     popd
     rm -rf /tmp/build
 fi
+
+#########################
+# iwyu - include-what-you-use
+
+if [[ ! -d /opt/compiler-explorer/iwyu/0.12 ]]; then
+    mkdir -p /tmp/build
+    pushd /tmp/build
+
+    curl https://include-what-you-use.org/downloads/include-what-you-use-0.12.src.tar.gz | tar xzf -
+    cd include-what-you-use/
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_PREFIX_PATH=/opt/compiler-explorer/clang-8.0.0/ -DCMAKE_INSTALL_PREFIX=/opt/compiler-explorer/iwyu/0.12
+    cmake --build . --target install
+    ln -s /opt/compiler-explorer/clang-8.0.0/lib /opt/compiler-explorer/iwyu/0.12/lib
+
+    popd
+    rm -rf /tmp/build
+fi

--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -94,7 +94,7 @@ fi
 #########################
 # iwyu - include-what-you-use
 
-if [[ ! -d /opt/compiler-explorer/iwyu/0.12 ]]; then
+if [[ ! -d ${OPT}/iwyu/0.12 ]]; then
     mkdir -p /tmp/build
     pushd /tmp/build
 
@@ -102,9 +102,9 @@ if [[ ! -d /opt/compiler-explorer/iwyu/0.12 ]]; then
     cd include-what-you-use/
     mkdir build
     cd build
-    ${OPT}/cmake/bin/cmake .. -DCMAKE_PREFIX_PATH=/opt/compiler-explorer/clang-8.0.0/ -DCMAKE_INSTALL_PREFIX=/opt/compiler-explorer/iwyu/0.12
+    ${OPT}/cmake/bin/cmake .. -DCMAKE_PREFIX_PATH=${OPT}/clang-8.0.0/ -DCMAKE_INSTALL_PREFIX=${OPT}/iwyu/0.12
     ${OPT}/cmake/bin/cmake --build . --target install
-    ln -s /opt/compiler-explorer/clang-8.0.0/lib /opt/compiler-explorer/iwyu/0.12/lib
+    ln -s ${OPT}/clang-8.0.0/lib ${OPT}/iwyu/0.12/lib
 
     popd
     rm -rf /tmp/build

--- a/update_compilers/install_binaries.sh
+++ b/update_compilers/install_binaries.sh
@@ -102,8 +102,8 @@ if [[ ! -d /opt/compiler-explorer/iwyu/0.12 ]]; then
     cd include-what-you-use/
     mkdir build
     cd build
-    cmake .. -DCMAKE_PREFIX_PATH=/opt/compiler-explorer/clang-8.0.0/ -DCMAKE_INSTALL_PREFIX=/opt/compiler-explorer/iwyu/0.12
-    cmake --build . --target install
+    ${OPT}/cmake/bin/cmake .. -DCMAKE_PREFIX_PATH=/opt/compiler-explorer/clang-8.0.0/ -DCMAKE_INSTALL_PREFIX=/opt/compiler-explorer/iwyu/0.12
+    ${OPT}/cmake/bin/cmake --build . --target install
     ln -s /opt/compiler-explorer/clang-8.0.0/lib /opt/compiler-explorer/iwyu/0.12/lib
 
     popd


### PR DESCRIPTION
For some reason, this can't install more than once on my CE VM. 

First installation went without a hitch, I deleted the folder, ran it again, poof.

This is the "error" it produced, it's not very useful.
```
 /usr/lib/gcc/x86_64-linux-gnu/7/collect2 -plugin /usr/lib/gcc/x86_64-linux-gnu/7/liblto_plugin.so -plugin-opt=/usr/lib/gcc/x86_64-linux-gnu/7/lto-wrapper -plugin-opt=-fresolution=/tmp/ccf1lUeS.res -plugin-opt=-pass-through=-lgcc_s -plugin-opt=-pass-through=-lgcc -plugin-opt=-pass-through=-lc -plugin-opt=-pass-through=-lgcc_s -plugin-opt=-pass-through=-lgcc --sysroot=/ --build-id --eh-frame-hdr -m elf_x86_64 --hash-style=gnu --as-needed -dynamic-linker /lib64/ld-linux-x86-64.so.2 -pie -z now -z relro -o bin/include-what-you-use /usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/Scrt1.o /usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/7/crtbeginS.o -L/usr/lib/gcc/x86_64-linux-gnu/7 -L/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/7/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/7/../../.. -rpath-link "" -O3 --gc-sections CMakeFiles/include-what-you-use.dir/iwyu.cc.o CMakeFiles/include-what-you-use.dir/iwyu_ast_util.cc.o CMakeFiles/include-what-you-use.dir/iwyu_cache.cc.o CMakeFiles/include-what-you-use.dir/iwyu_driver.cc.o CMakeFiles/include-what-you-use.dir/iwyu_getopt.cc.o CMakeFiles/include-what-you-use.dir/iwyu_globals.cc.o CMakeFiles/include-what-you-use.dir/iwyu_include_picker.cc.o CMakeFiles/include-what-you-use.dir/iwyu_lexer_utils.cc.o CMakeFiles/include-what-you-use.dir/iwyu_location_util.cc.o CMakeFiles/include-what-you-use.dir/iwyu_output.cc.o CMakeFiles/include-what-you-use.dir/iwyu_path_util.cc.o CMakeFiles/include-what-you-use.dir/iwyu_preprocessor.cc.o CMakeFiles/include-what-you-use.dir/iwyu_verrs.cc.o -rpath $ORIGIN/../lib:/opt/compiler-explorer/clang-8.0.0/lib /opt/compiler-explorer/clang-8.0.0/lib/libLLVMOption.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMSupport.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMX86AsmParser.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMX86Desc.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMX86Info.a -lpthread /opt/compiler-explorer/clang-8.0.0/lib/libclangBasic.a /opt/compiler-explorer/clang-8.0.0/lib/libclangLex.a /opt/compiler-explorer/clang-8.0.0/lib/libclangAST.a /opt/compiler-explorer/clang-8.0.0/lib/libclangSema.a /opt/compiler-explorer/clang-8.0.0/lib/libclangFrontend.a /opt/compiler-explorer/clang-8.0.0/lib/libclangDriver.a /opt/compiler-explorer/clang-8.0.0/lib/libclangSerialization.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMMCDisassembler.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMObject.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMX86AsmPrinter.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMX86Utils.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMOption.a /opt/compiler-explorer/clang-8.0.0/lib/libclangParse.a /opt/compiler-explorer/clang-8.0.0/lib/libclangSema.a /opt/compiler-explorer/clang-8.0.0/lib/libclangAnalysis.a /opt/compiler-explorer/clang-8.0.0/lib/libclangASTMatchers.a /opt/compiler-explorer/clang-8.0.0/lib/libclangEdit.a /opt/compiler-explorer/clang-8.0.0/lib/libclangAST.a /opt/compiler-explorer/clang-8.0.0/lib/libclangLex.a /opt/compiler-explorer/clang-8.0.0/lib/libclangBasic.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMMCParser.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMMC.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMDebugInfoCodeView.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMDebugInfoMSF.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMBitReader.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMProfileData.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMCore.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMBinaryFormat.a /opt/compiler-explorer/clang-8.0.0/lib/libLLVMSupport.a -lz -lrt -ldl -lpthread /opt/compiler-explorer/clang-8.0.0/lib/libLLVMDemangle.a -lstdc++ -lm -lgcc_s -lgcc -lc -lgcc_s -lgcc /usr/lib/gcc/x86_64-linux-gnu/7/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/crtn.o
collect2: error: ld returned 1 exit status
CMakeFiles/include-what-you-use.dir/build.make:444: recipe for target 'bin/include-what-you-use' failed
make[2]: *** [bin/include-what-you-use] Error 1
make[2]: Leaving directory '/tmp/build/include-what-you-use/build'
CMakeFiles/Makefile2:134: recipe for target 'CMakeFiles/include-what-you-use.dir/all' failed
make[1]: *** [CMakeFiles/include-what-you-use.dir/all] Error 2
make[1]: Leaving directory '/tmp/build/include-what-you-use/build'
Makefile:132: recipe for target 'all' failed
make: *** [all] Error 2
```

I'm gonna try it on the admin node and see what it does there, maybe it's just an issue with my VM.

