### PR TITLE
gcc-cross: k1: add SHA1 for latest versions

### DIFF
--- a/gcc-cross/build/latest/k1-7.4.1.config
+++ b/gcc-cross/build/latest/k1-7.4.1.config
@@ -258,7 +258,7 @@ CT_BINUTILS_DEVEL_VCS_git=y
 CT_BINUTILS_DEVEL_VCS="git"
 CT_BINUTILS_DEVEL_URL="https://github.com/kalray/gdb-binutils.git"
 CT_BINUTILS_DEVEL_BRANCH="coolidge"
-CT_BINUTILS_DEVEL_REVISION=""
+CT_BINUTILS_DEVEL_REVISION="ca74c0271fbed3fd0307056db6831baf74bb7392"
 CT_BINUTILS_DEVEL_SUBDIR=""
 CT_BINUTILS_DEVEL_BOOTSTRAP=""
 # CT_BINUTILS_SRC_CUSTOM is not set
@@ -335,7 +335,7 @@ CT_NEWLIB_DEVEL_VCS_git=y
 CT_NEWLIB_DEVEL_VCS="git"
 CT_NEWLIB_DEVEL_URL="https://github.com/kalray/newlib.git"
 CT_NEWLIB_DEVEL_BRANCH="coolidge"
-CT_NEWLIB_DEVEL_REVISION=""
+CT_NEWLIB_DEVEL_REVISION="6a49427d1df86abc54713b157d71a6e99f21355f"
 CT_NEWLIB_DEVEL_SUBDIR=""
 CT_NEWLIB_DEVEL_BOOTSTRAP=""
 # CT_NEWLIB_SRC_CUSTOM is not set
@@ -430,7 +430,7 @@ CT_GCC_DEVEL_VCS_git=y
 CT_GCC_DEVEL_VCS="git"
 CT_GCC_DEVEL_URL="https://github.com/kalray/gcc.git"
 CT_GCC_DEVEL_BRANCH="coolidge"
-CT_GCC_DEVEL_REVISION=""
+CT_GCC_DEVEL_REVISION="6b3d63f69bfef7e69a0c171340eb7e4c42e97325"
 CT_GCC_DEVEL_SUBDIR=""
 CT_GCC_DEVEL_BOOTSTRAP=""
 # CT_GCC_SRC_CUSTOM is not set
@@ -517,27 +517,6 @@ CT_CC_LANG_OTHERS=""
 # Debug facilities
 #
 # CT_DEBUG_GDB is not set
-# CT_GDB_USE_GNU is not set
-# CT_GDB_SRC_RELEASE is not set
-# CT_GDB_SRC_DEVEL is not set
-# CT_GDB_DEVEL_VCS_git is not set
-# CT_GDB_DEVEL_VCS_svn is not set
-# CT_GDB_DEVEL_VCS_hg is not set
-# CT_GDB_DEVEL_VCS_cvs is not set
-# CT_GDB_SRC_CUSTOM is not set
-# CT_GDB_PATCH_GLOBAL is not set
-# CT_GDB_PATCH_BUNDLED is not set
-# CT_GDB_PATCH_LOCAL is not set
-# CT_GDB_PATCH_BUNDLED_LOCAL is not set
-# CT_GDB_PATCH_LOCAL_BUNDLED is not set
-# CT_GDB_PATCH_NONE is not set
-# CT_GDB_VERY_NEW is not set
-# CT_GDB_V_8_3 is not set
-# CT_GDB_V_8_2 is not set
-# CT_GDB_V_8_1 is not set
-# CT_GDB_V_8_0 is not set
-# CT_GDB_V_7_12 is not set
-# CT_GDB_V_7_11 is not set
 # CT_DEBUG_LTRACE is not set
 # CT_DEBUG_STRACE is not set
 CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"


### PR DESCRIPTION
Points to latest version of K1 MPPA ports for gdb/binutils, newlib and gcc.