### PR TITLE
Add GCC static analysis branch

### DIFF
--- a/admin-daily-builds.sh
+++ b/admin-daily-builds.sh
@@ -45,6 +45,7 @@ build_latest gcc gcc_contracts build.sh lock3-contracts-trunk
 build_latest gcc gcc_modules build.sh cxx-modules-trunk
 build_latest gcc gcc_coroutines build.sh cxx-coroutines-trunk
 build_latest gcc gcc_embed build.sh embed-trunk
+build_latest gcc gcc_static_analysis build.sh static-analysis-trunk
 build_latest clang clang build.sh trunk
 build_latest clang clang_concepts build-concepts.sh trunk
 build_latest clang clang_cppx build-cppx.sh trunk

--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -303,6 +303,7 @@ compilers:
           - cxx-modules-trunk
           - cxx-coroutines-trunk
           - embed-trunk
+          - static-analysis-trunk
       clang:
         type: nightly
         check_exe: bin/clang++ --version

--- a/gcc/build/build.sh
+++ b/gcc/build/build.sh
@@ -5,6 +5,7 @@ set -ex
 ROOT=$(pwd)
 VERSION=$1
 LANGUAGES=c,c++,fortran,ada
+PLUGINS=
 if echo "${VERSION}" | grep 'embed-trunk'; then
     VERSION=embed-trunk-$(date +%Y%m%d)
     URL=https://github.com/ThePhD/gcc.git
@@ -31,6 +32,14 @@ elif echo "${VERSION}" | grep 'cxx-coroutines-trunk'; then
     MAJOR=10
     MAJOR_MINOR=10-trunk
     LANGUAGES=c,c++
+elif echo "${VERSION}" | grep 'static-analysis-trunk'; then
+    VERSION=static-analysis-trunk-$(date +%Y%m%d)
+    URL=https://gcc.gnu.org/git/gcc.git/
+    BRANCH=dmalcolm/analyzer
+    MAJOR=10
+    MAJOR_MINOR=10-trunk
+    LANGUAGES=c,c++
+    PLUGINS=analyzer
 elif echo "${VERSION}" | grep 'trunk'; then
     VERSION=trunk-$(date +%Y%m%d)
     URL=svn://gcc.gnu.org/svn/gcc/trunk
@@ -148,6 +157,10 @@ CONFIG+=" --enable-lto"
 CONFIG+=" --enable-plugins"
 CONFIG+=" --enable-threads=posix"
 CONFIG+=" --with-pkgversion=Compiler-Explorer-Build"
+# The static analyzer branch adds a --enable-plugins configuration option
+if [[ ! -z "${PLUGINS}" ]]; then
+    CONFIG+=" --enable-plugins=${PLUGINS}"
+fi
 BINUTILS_VERSION=2.29.1
 
 applyPatchesAndConfig gcc${MAJOR}


### PR DESCRIPTION
Add a daily build of the git-only branch "dmalcolm/analyzer" hosted on
the GCC git mirror.

See https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer

The branch adds support for in-tree GCC plugins, adding a
  --enable-plugins=
configuration option analogous to --enable-languages, and
the analyzer is itself implemented as the first example of
such an in-tree plugin.

Hence add a PLUGINS variable to build.sh analogous to LANGUAGES.