### PR TITLE
Switch my "P1144" compiler to use the LLVM monorepo

### DIFF
--- a/clang/build/build-relocatable.sh
+++ b/clang/build/build-relocatable.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-set -e
+set -ex
 
-# Grab CE's GCC 7.3.0 for its binutils (which is what the site uses to link currently)
+# Grab CE's GCC for its binutils
+BINUTILS_GCC_VERSION=9.2.0
 mkdir -p /opt/compiler-explorer
 pushd /opt/compiler-explorer
-curl -sL https://s3.amazonaws.com/compiler-explorer/opt/gcc-7.3.0.tar.xz | tar Jxf -
+curl -sL https://s3.amazonaws.com/compiler-explorer/opt/gcc-${BINUTILS_GCC_VERSION}.tar.xz | tar Jxf -
 popd
 
 ROOT=$(pwd)
@@ -24,25 +25,25 @@ STAGING_DIR=$(pwd)/staging
 rm -rf ${STAGING_DIR}
 mkdir -p ${STAGING_DIR}
 
-git clone https://github.com/llvm-mirror/llvm
-pushd llvm/tools
-git clone --depth 20 --single-branch -b trivially-relocatable https://github.com/Quuxplusone/clang
-source ./clang/compiler-explorer-llvm-commit.sh
-cd clang && git log HEAD~10...HEAD --oneline
-popd
-pushd llvm/projects
-git clone --depth 20 --single-branch -b trivially-relocatable https://github.com/Quuxplusone/libcxx
-git clone --depth 20 --single-branch -b master https://github.com/llvm-mirror/libcxxabi
-popd
+# Setup llvm-project checkout
+git clone --depth 20 --single-branch -b trivially-relocatable https://github.com/Quuxplusone/llvm-project.git
 
+# Print a git log for debugging purposes
+(cd llvm-project && git log HEAD~10...HEAD --oneline)
+
+# Setup build directory and build configuration
 mkdir build
 cd build
-cmake -G "Unix Makefiles" ../llvm \
+cmake -G "Unix Makefiles" ../llvm-project/llvm \
+    -DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;compiler-rt;lld;polly;clang-tools-extra" \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=/root/staging \
-    -DLLVM_BINUTILS_INCDIR:PATH=/opt/compiler-explorer/gcc-7.3.0/lib/gcc/x86_64-linux-gnu/7.3.0/plugin/include/
+    -DLLVM_BINUTILS_INCDIR:PATH=/opt/compiler-explorer/gcc-${BINUTILS_GCC_VERSION}/lib/gcc/x86_64-linux-gnu/${BINUTILS_GCC_VERSION}/plugin/include
 
+# Build and install artifacts
 make -j$(nproc) install
+
+# Don't try to compress the binaries as they don't like it
 
 export XZ_DEFAULTS="-T 0"
 tar Jcf ${OUTPUT} --transform "s,^./,./clang-${VERSION}/," -C ${STAGING_DIR} .


### PR DESCRIPTION
llvm-mirror is no longer being updated. https://github.com/Quuxplusone/llvm-project is the new home of the "trivially-relocatable" branch.

I've tried to minimize the diff between build.sh and build-relocatable.sh.

----

ATTENTION MAINTAINERS: What's the best way to test this before it goes live? Or, you could just deploy it and then revert it if the new image doesn't build or builds wrong in some way. (The current/old version of "build-relocatable.sh" does still "work," in that it generates deployable compiler images, but it's pulling from a repo that is no longer updated.)