### PR TITLE
Updated Catch2 library to version 2.11.1

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -233,7 +233,7 @@ get_github_versioned_and_trunk libs/fmt fmtlib/fmt 6.1.0 6.0.0 5.3.0 5.2.0 5.1.0
 get_github_versioned_and_trunk libs/hfsm andrew-gresyk/HFSM 0.8 0.10
 get_gitlab_versioned_and_trunk_with_quirk libs/eigen libeigen/eigen v 3.3.4 3.3.5 3.3.7
 get_github_versioned_and_trunk libs/glm g-truc/glm 0.9.8.5 0.9.9.0 0.9.9.1 0.9.9.2 0.9.9.3 0.9.9.4 0.9.9.5 0.9.9.6
-get_github_versioned_and_trunk libs/catch2 catchorg/Catch2 v2.2.2 v2.2.3 v2.3.0 v2.4.0 v2.4.1 v2.4.2 v2.5.0 v2.6.0 v2.6.1 v2.7.0 v2.7.1 v2.7.2 v2.8.0 v2.9.0 v2.9.1 v2.9.2
+get_github_versioned_and_trunk libs/catch2 catchorg/Catch2 v2.2.2 v2.2.3 v2.3.0 v2.4.0 v2.4.1 v2.4.2 v2.5.0 v2.6.0 v2.6.1 v2.7.0 v2.7.1 v2.7.2 v2.8.0 v2.9.0 v2.9.1 v2.9.2 v2.10.0 v2.10.1 v2.10.2 v2.11.0 v2.11.1
 get_github_versions libs/expected-lite martinmoene/expected-dark v0.0.1
 get_github_versioned_and_trunk libs/expected-lite martinmoene/expected-lite v0.1.0
 get_github_versioned_and_trunk libs/nlohmann_json nlohmann/json v3.6.0 v3.1.2 v2.1.1


### PR DESCRIPTION
Relates to this [PR](https://github.com/mattgodbolt/compiler-explorer/pull/1775)