### PR TITLE
Support installing llvm library from ce_install

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -1,0 +1,26 @@
+libraries:
+  c++:
+    llvm:
+      type: s3tarballs
+      path_name: libs/llvm/{name}
+      check_file: include/llvm/Config/llvm-config.h
+      targets:
+        - 4.0.1
+        - 5.0.0
+        - 5.0.1
+        - 5.0.2
+        - 6.0.0
+        - 6.0.1
+        - 7.0.0
+        - 7.0.1
+        - 8.0.0
+        - 9.0.0
+    nightly:
+      if: nightly
+      llvm:
+        type: nightly
+        subdir: libs/llvm
+        symlink: libs/llvm/{name}
+        check_file: include/llvm/Config/llvm-config.h
+        targets:
+          - trunk


### PR DESCRIPTION
Definitely not one of my finer hack jobs, but it does appear to get things done for now.

Things were not as straight forward as I was hoping in the python side of things because of the directory structure of the libraries.  In the end it may be better to create a new installable type specifically for libraries rather than hack it into the nightlies target?

Or honestly, we could just let the nightlies get installed at the root and fix things up on the CE side of things?

Any feedback is welcome on this one, I'm not really in love with it.