### PR TITLE
Rename and update MPPA compiler

### DIFF
--- a/bin/yaml/cpp.yaml
+++ b/bin/yaml/cpp.yaml
@@ -222,6 +222,12 @@ compilers:
           targets:
             - 7.4.1
             - 7.5.0
+        kvx:
+          arch_prefix: "kvx-unknown-elf"
+          check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"
+          subdir: kvx
+          targets:
+            - 7.5.0
         powerpc:
           arch_prefix: "{subdir}-unknown-linux-gnu"
           check_exe: "{arch_prefix}/bin/{arch_prefix}-g++ --version"

--- a/build_cross_compilers.sh
+++ b/build_cross_compilers.sh
@@ -54,5 +54,6 @@ build_cross arm64 8.2.0
 build_cross riscv64 8.2.0
 build_cross k1 7.4.1
 build_cross k1 7.5.0
+build_cross kvx 7.5.0
 
 exit ${BUILD_FAILED}


### PR DESCRIPTION
Kalray's core has been renamed from k1/k1c to kvx/kv3.
It has been decided with Matt that the easiest solution is to remove
the old compilers and replace with the new one with correct name.