### PR TITLE
Add Go 1.14

### DIFF
--- a/bin/yaml/go.yaml
+++ b/bin/yaml/go.yaml
@@ -21,6 +21,7 @@ compilers:
         - "1.11"
         - "1.12"
         - "1.13"
+        - "1.14"
     nightly:
       if: nightly
       type: nightly

--- a/update_compilers/install_go_compilers.sh
+++ b/update_compilers/install_go_compilers.sh
@@ -61,6 +61,7 @@ install_golang 1.10.1
 install_golang 1.11
 install_golang 1.12
 install_golang 1.13
+install_golang 1.14
 
 if install_nightly; then
     do_nightly_install go-trunk go-tip


### PR DESCRIPTION
Go 1.14 came out earlier this year [link to release notes](https://golang.org/doc/devel/release.html#go1.14). This PR just copy and pasted the changes that were done to add 1.13 (and incremented the version number). I did not test locally, PR to compiler-explorer comes in a second with a [link here](FIXME).