### PR TITLE
Update fmt library to version 6.2.0

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -199,7 +199,7 @@ get_github_versioned_and_trunk libs/mp-units mpusz/units v0.3.1 v0.4.0
 get_github_versioned_and_trunk libs/dlib davisking/dlib v19.7 v19.9 v19.10
 get_github_versioned_and_trunk libs/libguarded copperspice/cs_libguarded libguarded-1.1.0
 get_github_versioned_and_trunk libs/brigand edouarda/brigand 1.3.0
-get_github_versioned_and_trunk libs/fmt fmtlib/fmt 4.0.0 4.1.0 5.0.0 5.1.0 5.2.0 5.3.0 6.0.0 6.1.0 6.1.1 6.1.2
+get_github_versioned_and_trunk libs/fmt fmtlib/fmt 4.0.0 4.1.0 5.0.0 5.1.0 5.2.0 5.3.0 6.0.0 6.1.0 6.1.1 6.1.2 6.2.0
 get_github_versioned_and_trunk libs/hfsm andrew-gresyk/HFSM 0.8 0.10
 get_gitlab_versioned_and_trunk_with_quirk libs/eigen libeigen/eigen v 3.3.4 3.3.5 3.3.7
 get_github_versioned_and_trunk libs/glm g-truc/glm 0.9.8.5 0.9.9.0 0.9.9.1 0.9.9.2 0.9.9.3 0.9.9.4 0.9.9.5 0.9.9.6 0.9.9.7 0.9.9.8


### PR DESCRIPTION
Requires [this](https://github.com/mattgodbolt/compiler-explorer/pull/1939) PR to merged as well.