### PR TITLE
Update Google benchmark library to version 1.5.0

### DIFF
--- a/update_compilers/install_libraries.sh
+++ b/update_compilers/install_libraries.sh
@@ -193,7 +193,7 @@ get_github_versioned_and_trunk() {
 }
 
 get_github_versioned_and_trunk libs/ulib stefanocasazza/ULib v1.4.2
-get_github_versioned_and_trunk libs/google-benchmark google/benchmark v1.2.0 v1.3.0 v1.4.0
+get_github_versioned_and_trunk libs/google-benchmark google/benchmark v1.2.0 v1.3.0 v1.4.0 v1.4.1 v1.5.0
 get_github_versioned_and_trunk libs/rangesv3 ericniebler/range-v3 0.3.0 0.3.5 0.3.6 0.4.0 0.9.1 0.10.0
 get_github_versioned_and_trunk libs/mp-units mpusz/units v0.3.1 v0.4.0
 get_github_versioned_and_trunk libs/dlib davisking/dlib v19.7 v19.9 v19.10


### PR DESCRIPTION
Requires [this](https://github.com/mattgodbolt/compiler-explorer/pull/1941) PR to merged as well.