### PR TITLE
Updated fmtlib library to version 6.2.1

### DIFF
--- a/bin/yaml/libraries.yaml
+++ b/bin/yaml/libraries.yaml
@@ -42,6 +42,7 @@ libraries:
         - 6.1.1
         - 6.1.2
         - 6.2.0
+        - 6.2.1
       build_type: cmake
     benchmark:
       type: github


### PR DESCRIPTION
Requires [this](https://github.com/mattgodbolt/compiler-explorer/pull/1959) PR to be merged as well.